### PR TITLE
2019 EU Elections pt4 - rename 'Event' to 'Location', fix API charset

### DIFF
--- a/src/main-news-app/pages/index.php
+++ b/src/main-news-app/pages/index.php
@@ -26,7 +26,7 @@ echo "</script> \r\n";
     <!-- Event selection -->
     <div class="major row">
       <div class="group">
-        <span>Event:</span>
+        <span>Location:</span>
         <select id="filter-event">
           <?php foreach ($config->events as $eventName => $eventDetails) { ?>
             <option

--- a/web/index.php
+++ b/web/index.php
@@ -180,7 +180,7 @@ function print_json($data) {
     <!-- Event selection -->
     <div class="major row">
       <div class="group">
-        <span>Event:</span>
+        <span>Location:</span>
         <select id="filter-event">
           <?php foreach ($config->events as $eventName => $eventDetails) { ?>
             <option

--- a/web/news/api/index.php
+++ b/web/news/api/index.php
@@ -32,6 +32,9 @@ if (!$sql_connection->select_db($db_database)) {
   die("Database Selection Error");
 }
 
+//Set Character Set to UTF-8 to handle accented characters, etc.
+$sql_connection->set_charset("utf8");
+
 //Get any query variables.
 $input_debug = varGet("debug");
 $input_message = trim(varGet("message"));

--- a/web/news/app/index.php
+++ b/web/news/app/index.php
@@ -26,7 +26,7 @@ echo "</script> \r\n";
     <!-- Event selection -->
     <div class="major row">
       <div class="group">
-        <span>Event:</span>
+        <span>Location:</span>
         <select id="filter-event">
           <?php foreach ($config->events as $eventName => $eventDetails) { ?>
             <option

--- a/web/news/files/app-config.json
+++ b/web/news/files/app-config.json
@@ -20,7 +20,7 @@
   },
   "events": {
     "EU2019": {
-      "label": "EU Elections 2019",
+      "label": "EU",
       "top10file": "eu2019_top10.json",
       "top256file": "eu2019_top256.json",
       "languages": {
@@ -34,7 +34,7 @@
       }
     },
     "USmidterms2018": {
-      "label": "US Midterm Elections 2018",
+      "label": "US",
       "top10file": "usmidterms2018_top10.json",
       "top256file": "usmidterms2018_top256.json",
       "languages": {

--- a/web/top10.php
+++ b/web/top10.php
@@ -230,7 +230,7 @@ function print_json($data) {
     <!-- Event selection -->
     <div class="major row">
       <div class="group">
-        <span>Event:</span>
+        <span>Location:</span>
         <select id="filter-event">
           <?php foreach ($config->events as $eventName => $eventDetails) { ?>
             <option


### PR DESCRIPTION
## PR Overview

This PR addresses some feedback from OII
- 'Event' has been renamed to 'Location' on the UI
- the issue with the API returning `?` characters in place of accented characters like `é` (and other non-'standard Latin' characters) has been fixed.
  - turns out the issue was related to the API getting the MySQL results in Latin; forcing the character set to `UTF8` fixes this issue.